### PR TITLE
FreeBSD & OpenBSD client support

### DIFF
--- a/bin/pakiti-client
+++ b/bin/pakiti-client
@@ -194,6 +194,14 @@ sub find_system ($) {
             return;
         }
     }
+    $path = "/etc/freebsd-update.conf";
+    if (-f $path) {
+        $data->{system} = `uname -rs`;
+    }
+    $path = "/etc/mygate";
+    if (-f $path) {
+        $data->{system} = `uname -rsv`;
+    }
     # Linux Standard Base
     if ($Option{lsb_release}) {
         $output = output1($Option{lsb_release}, "-i");
@@ -238,6 +246,20 @@ sub find_packages ($) {
         $data->{packager} = "dpkg";
         $data->{packages} = "";
         die("NYI");
+    }
+    # FreeBSD (pkgng) or OpenBSD package
+    if ($Option{"pkg"}) {
+        $data->{packager} = "pkg";
+        my $arch = `uname -m`;
+        foreach my $line (qx($Option{pkg} info | awk "{print \\\$1}")) {
+            my ($prog, $dump) = split /-[0-9]/, $line;
+            $line =~ s/$prog-//;
+            chomp($line);
+            my $record = sprintf("%s\t%s\t''\t%s", $prog, $line, $arch);
+            push(@list, $record);
+        }
+        $data->{packages} = join("", sort(@list));
+        return;
     }
     # unknown!
     die("$Script: unknown package manager\n");


### PR DESCRIPTION
FreeBSD (pkgng) and OpenBSD pkg support.
$Option{pkg} should be /usr/sbin/pkg.

Changing the (qx($Option{pkg} info ....)) to (qx($Option{pkginfo} ...)) having $Option{pkginfo} = /usr/sbin/pkg_info, the same code can be used for FreeBSD former package manager.