### PR TITLE
fix cern report

### DIFF
--- a/lib/managers/HostsManager.php
+++ b/lib/managers/HostsManager.php
@@ -53,7 +53,7 @@ class HostsManager extends DefaultManager {
       Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);
       throw new Exception("Host object is not valid or Host.id is not set");
     } 
-    
+        
     # Get the osId
     $host->setOsName($this->guessOs($host, $pkgs));
     $osDao = $this->getPakiti()->getDao("Os");
@@ -344,8 +344,10 @@ class HostsManager extends DefaultManager {
     # Find the package which represents the OS name/release
     foreach (Constants::$OS_NAMES_DEFINITIONS as $pkgName => &$osName) {
       if (array_key_exists($pkgName, $pkgs)) {
-        // Remove epoch if there is one
-        $osFullName = $osName . " " . Utils::removeEpoch($pkgs[$pkgName]["pkgVersion"]);
+        foreach ($pkgs[$pkgName] as $pkg){
+          // Remove epoch if there is one
+          $osFullName = $osName . " " . Utils::removeEpoch($pkg["pkgVersion"]);
+        }
       }
     }
     unset($osName);  

--- a/lib/managers/HostsManager.php
+++ b/lib/managers/HostsManager.php
@@ -53,7 +53,7 @@ class HostsManager extends DefaultManager {
       Utils::log(LOG_ERR, "Exception", __FILE__, __LINE__);
       throw new Exception("Host object is not valid or Host.id is not set");
     } 
-        
+    
     # Get the osId
     $host->setOsName($this->guessOs($host, $pkgs));
     $osDao = $this->getPakiti()->getDao("Os");

--- a/lib/modules/feeder/FeederModule.php
+++ b/lib/modules/feeder/FeederModule.php
@@ -208,7 +208,7 @@ class FeederModule extends DefaultModule
                     }
 
                     while (($line = fgets($handle)) !== false) {
-                        if ($line == "#" || empty($line)) continue;
+                        if (trim($line) == "#" || empty($line)) continue;
                         # Store packages into the internal variable
                         $this->_report_pkgs .= $line;
                     }
@@ -343,7 +343,7 @@ class FeederModule extends DefaultModule
             $currentReportPkgsHash = $this->computeReportPkgsHash();
 
             # Check if the hashes are equals
-            if (($lastReportHashes != null) && (($lastReportHashes[Constants::$REPORT_LAST_HEADER_HASH] == $currentReportPkgsHash) ||
+            if (($lastReportHashes != null) && (($lastReportHashes[Constants::$REPORT_LAST_HEADER_HASH] == $currentReportHeaderHash) &&
                     ($lastReportHashes[Constants::$REPORT_LAST_PKGS_HASH] == $currentReportPkgsHash))
             ) {
                 # Data sent by the host are the same as stored one, so we do not need to store anything
@@ -609,21 +609,17 @@ class FeederModule extends DefaultModule
     protected function computeReportHeaderHash()
     {
         Utils::log(LOG_DEBUG, "Computing the hash of the report header", __FILE__, __LINE__);
-        switch ($this->_version) {
-            case "4":
-                $header = Utils::getHttpVar(Constants::$REPORT_TYPE) .
-                    Utils::getHttpVar(Constants::$REPORT_HOSTNAME) .
-                    Utils::getHttpVar(Constants::$REPORT_OS) .
-                    Utils::getHttpVar(Constants::$REPORT_TAG) .
-                    Utils::getHttpVar(Constants::$REPORT_KERNEL) .
-                    Utils::getHttpVar(Constants::$REPORT_ARCH) .
-                    Utils::getHttpVar(Constants::$REPORT_SITE) .
-                    Utils::getHttpVar(Constants::$REPORT_VERSION) .
-                    Utils::getHttpVar(Constants::$REPORT_REPORT);
-
-                return $this->computeHash($header);
-                break;
-        }
+        $header = 
+            $this->_report_type .
+            $this->_report_hostname .
+            $this->_report_os .
+            $this->_report_tag .
+            $this->_report_kernel .
+            $this->_report_arch .
+            $this->_report_site .
+            $this->_version .
+            $this->_report_report;
+        return $this->computeHash($header);
     }
 
     /*
@@ -632,7 +628,7 @@ class FeederModule extends DefaultModule
     protected function computeReportPkgsHash()
     {
         Utils::log(LOG_DEBUG, "Computing the hash of the list of the packages", __FILE__, __LINE__);
-        return $this->computeHash(Utils::getHttpVar(Constants::$REPORT_PKGS));
+        return $this->computeHash($this->_report_pkgs);
     }
 
     /*


### PR DESCRIPTION
- fix detect end of packages list in cern report

- fix wrong variable in hashes comparison

- fix compute hash,
variables which used in computeHash are loaded in local variables and therefore not necessary to load again from http variables,
in cern report must be used local variables because http variables doesn't exist

- fix find the package to guess OS because of problem with variable structure