### PR TITLE
fix processing not encrypted cern report

### DIFF
--- a/etc/Config.php.template
+++ b/etc/Config.php.template
@@ -63,8 +63,8 @@ final class Config
     # Should be report compressed?
     public static $COMPRESS_REPORTS = 1;
 
-    # If CERN reports are used, path to the private key must be defined, in order to decrypt incomming report
-    public static $CERN_REPORT_DECRYPTION_KEY = "/etc/ssl/localcerts/pakiti3.key";
+    # If pakiti-client v3 are used, path to the private key must be defined, in order to decrypt incomming report
+    public static $REPORT_DECRYPTION_KEY = "/etc/ssl/localcerts/pakiti3.key";
 
     # Do we want backup the reports
     public static $BACKUP = FALSE;

--- a/lib/common/Constants.php
+++ b/lib/common/Constants.php
@@ -128,5 +128,9 @@ final class Constants {
   
   # Does the host sending also its own repositories definitions?
   public static $OWN_REPOSITORIES_DEF = 1;
+
+  # Mime type of encrypted report
+  public static $MIME_TYPE_ENCRYPTED_REPORT = "application/octet-stream";
+
 }
 ?>


### PR DESCRIPTION
- check mime type of report before decryption
- if mime type is not application/octet-stream try to use report without decryption