### PR TITLE
Handle SUSE Open Enterprise variants.

### DIFF
--- a/src/common/Utils.php
+++ b/src/common/Utils.php
@@ -16,7 +16,7 @@ final class Utils
     }
 
     /**
-     * Return current Pakiti version (it is stored in the src/classess/Constants.php
+     * Return current Pakiti version (it is stored in the src/common/Constants.php
      */
     public static function pakitiVersion()
     {

--- a/src/managers/OsesManager.php
+++ b/src/managers/OsesManager.php
@@ -44,7 +44,7 @@ class OsesManager extends DefaultManager
             if (!empty(Config::$OS_GROUPS_MAPPING[$osGroupName]) && preg_match("/" . htmlspecialchars_decode(Config::$OS_GROUPS_MAPPING[$osGroupName]). "/", $os->getName()) == 1) {
                 $og = $osGroupsManager->getOsGroupByName($osGroupName);
                 if ($og == null) {
-                    /* group assignment is re-calculted on its adding */
+                    /* group assignment is re-calculated on its adding */
                     $new = new OsGroup();
                     $new->setName($osGroupName);
                     $osGroupsManager->storeOsGroup($new);

--- a/src/modules/vds/sources/CveSubSources/OvalSUSE.php
+++ b/src/modules/vds/sources/CveSubSources/OvalSUSE.php
@@ -108,7 +108,7 @@ class OvalSUSE extends SubSource implements ISubSource
             foreach ($criterions as $criterion) {
                 $comment = $criterion->attributes->getNamedItem('comment')->nodeValue;
                 //print "Comment: $comment\n";
-                if (strpos($comment, "SUSE") === 0 || strpos($comment, "openSUSE") === 0) {
+                if (strpos($comment, "SUSE") === 0 || strpos($comment, "openSUSE") === 0 || strpos($comment, "Open Enterprise") === 0) {
                     preg_match("/^(.*) is installed$/", $comment, $suse_release);
                     $os = $suse_release[1];
                     //print "Got OS: $os\n";


### PR DESCRIPTION
My logs are filling up with warnings:
```
PHP Warning:  Undefined array key 1 in /var/www/pakiti-server/src/modules/vds/sources/CveSubSources/OvalSUSE.php on line 118
PHP Warning:  Undefined array key 2 in /var/www/pakiti-server/src/modules/vds/sources/CveSubSources/OvalSUSE.php on line 119
PHP Warning:  Undefined array key 3 in /var/www/pakiti-server/src/modules/vds/sources/CveSubSources/OvalSUSE.php on line 120
```

This is because there are SUSE-variants called "Open Enterprise Server" and "Open Enterprise Storage", which don't use the name-version-release naming format of packages. This patch makes the "Open Enterprise" variants go through the os-codepath.